### PR TITLE
Issue #2080 : Allow Entry Time Configuration for the 'Contains' field…

### DIFF
--- a/src/main/java/org/jajuk/ui/views/CatalogView.java
+++ b/src/main/java/org/jajuk/ui/views/CatalogView.java
@@ -118,8 +118,6 @@ public class CatalogView extends ViewAdapter implements ActionListener, TwoSteps
   private boolean bNeedSearch = false;
   /** Populating flag. */
   private boolean bPopulating = false;
-  /** Default time in ms before launching a search automatically. */
-  private static final int WAIT_TIME = 600;
   /** Date last key pressed. */
   private long lDateTyped;
   /** Last selected item. */
@@ -135,10 +133,10 @@ public class CatalogView extends ViewAdapter implements ActionListener, TwoSteps
   /** Last scrollbar position *. */
   private int scrollPosition;
   /** Swing Timer to refresh the component. */
-  private final Timer timerSearch = new Timer(WAIT_TIME, new ActionListener() {
+  private final Timer timerSearch = new Timer(100, new ActionListener() {
     @Override
     public void actionPerformed(ActionEvent e) {
-      if (bNeedSearch && !bPopulating && (System.currentTimeMillis() - lDateTyped >= WAIT_TIME)) {
+      if (bNeedSearch && !bPopulating && (System.currentTimeMillis() - lDateTyped >= Conf.getInt(Const.CONF_CATALOG_AUTO_SEARCH_DELAY))) {
         // reset paging
         page = 0;
         populateCatalog();

--- a/src/main/java/org/jajuk/ui/widgets/SearchBox.java
+++ b/src/main/java/org/jajuk/ui/widgets/SearchBox.java
@@ -87,8 +87,6 @@ public class SearchBox extends JTextField implements KeyListener, ListSelectionL
   private static final long serialVersionUID = 1L;
   /** Do search panel need a search. */
   private boolean bNeedSearch = false;
-  /** Default time in ms before launching a search automatically. */
-  private static final int WAIT_TIME = 1000;
   /** Minimum number of characters to start a search. */
   private static final int MIN_CRITERIA_LENGTH = 2;
   /** Search result. */
@@ -102,7 +100,7 @@ public class SearchBox extends JTextField implements KeyListener, ListSelectionL
   Timer timer = new Timer(100, new ActionListener() {
     @Override
     public void actionPerformed(ActionEvent arg0) {
-      if (bNeedSearch && (System.currentTimeMillis() - lDateTyped >= WAIT_TIME)) {
+      if (bNeedSearch && (System.currentTimeMillis() - lDateTyped >= Conf.getInt(Const.CONF_SEARCH_AUTO_SEARCH_DELAY))) {
         search();
       }
     }

--- a/src/main/java/org/jajuk/util/Conf.java
+++ b/src/main/java/org/jajuk/util/Conf.java
@@ -317,6 +317,10 @@ public final class Conf implements Const {
     defaults.put(CONF_NOT_SHOW_AGAIN_LAF_CHANGE, FALSE);
     defaults.put(CONF_STATS_MIN_VALUE_GENRE_DISPLAY, "2");
     defaults.put(CONF_TARGET_WORKSPACE_PATH, UtilSystem.getUserHome());
+    // Search auto-search delay in milliseconds (default 1 second)
+    defaults.put(CONF_SEARCH_AUTO_SEARCH_DELAY, "1000");
+    // Catalog auto-search delay in milliseconds (default 1 second)
+    defaults.put(CONF_CATALOG_AUTO_SEARCH_DELAY, "1000");
     // Make a copy of default values
     properties = (Properties) defaults.clone();
   }

--- a/src/main/java/org/jajuk/util/Const.java
+++ b/src/main/java/org/jajuk/util/Const.java
@@ -496,6 +496,10 @@ public interface Const {
   String CONF_STARTUP_QUEUE_INDEX = "jajuk.current_file_index";
   /** Current item index in fifo. */
   String CONF_STATS_MIN_VALUE_GENRE_DISPLAY = "jajuk.stats.min_value_genre_display";
+  /** Search box auto-search delay in milliseconds. */
+  String CONF_SEARCH_AUTO_SEARCH_DELAY = "jajuk.search.auto_search_delay";
+  /** Catalog view auto-search delay in milliseconds. */
+  String CONF_CATALOG_AUTO_SEARCH_DELAY = "jajuk.catalog.auto_search_delay";
   /** Shuffle/novelties mode. */
   String MODE_ALBUM = "album";
   String MODE_TRACK = "track";


### PR DESCRIPTION
This PR allow configuration for autosearch Delay of Album Catalog and general SearchBox, default value 1000 ms

<img width="1477" height="178" alt="Capture d’écran du 2026-05-02 19-01-55" src="https://github.com/user-attachments/assets/482ae1cc-37aa-4d3b-b0dc-17e2fa2e0ad7" />


I wonder if this would be a good idea to apply this also to AbstractTableView ?